### PR TITLE
Added support for "dotnet tool"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -361,3 +361,4 @@ MigrationBackup/
 
 # Fody - auto-generated XML schema
 FodyWeavers.xsd
+/Onova.Installer/vcpkg_installed

--- a/.gitignore
+++ b/.gitignore
@@ -362,3 +362,4 @@ MigrationBackup/
 # Fody - auto-generated XML schema
 FodyWeavers.xsd
 /Onova.Installer/vcpkg_installed
+/.idea

--- a/Onova.Installer/Onova.Installer.cpp
+++ b/Onova.Installer/Onova.Installer.cpp
@@ -163,7 +163,7 @@ int main(int argc, char* argv[])
 	wcout << L"Copied uninstaller." << endl;
 #endif
 
-	wcout << L"The app was sucessfully installed." << endl;
+	wcout << L"The app was successfully installed." << endl;
 	system("pause");
 
 	return 0;

--- a/Onova.Installer/Onova.Installer.vcxproj
+++ b/Onova.Installer/Onova.Installer.vcxproj
@@ -1,179 +1,184 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-	<ItemGroup Label="ProjectConfigurations">
-		<ProjectConfiguration Include="Debug|Win32">
-			<Configuration>Debug</Configuration>
-			<Platform>Win32</Platform>
-		</ProjectConfiguration>
-		<ProjectConfiguration Include="Release|Win32">
-			<Configuration>Release</Configuration>
-			<Platform>Win32</Platform>
-		</ProjectConfiguration>
-		<ProjectConfiguration Include="Debug|x64">
-			<Configuration>Debug</Configuration>
-			<Platform>x64</Platform>
-		</ProjectConfiguration>
-		<ProjectConfiguration Include="Release|x64">
-			<Configuration>Release</Configuration>
-			<Platform>x64</Platform>
-		</ProjectConfiguration>
-	</ItemGroup>
-	<PropertyGroup Label="Globals">
-		<VCProjectVersion>16.0</VCProjectVersion>
-		<Keyword>Win32Proj</Keyword>
-		<ProjectGuid>{3b6ef307-2edc-44cf-9b98-7c98db4db804}</ProjectGuid>
-		<RootNamespace>OnovaInstaller</RootNamespace>
-		<WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
-	</PropertyGroup>
-	<Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
-		<ConfigurationType>Application</ConfigurationType>
-		<UseDebugLibraries>true</UseDebugLibraries>
-		<PlatformToolset>v143</PlatformToolset>
-		<CharacterSet>Unicode</CharacterSet>
-	</PropertyGroup>
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
-		<ConfigurationType>Application</ConfigurationType>
-		<UseDebugLibraries>false</UseDebugLibraries>
-		<PlatformToolset>v143</PlatformToolset>
-		<WholeProgramOptimization>true</WholeProgramOptimization>
-		<CharacterSet>Unicode</CharacterSet>
-	</PropertyGroup>
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
-		<ConfigurationType>Application</ConfigurationType>
-		<UseDebugLibraries>true</UseDebugLibraries>
-		<PlatformToolset>v143</PlatformToolset>
-		<CharacterSet>Unicode</CharacterSet>
-	</PropertyGroup>
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
-		<ConfigurationType>Application</ConfigurationType>
-		<UseDebugLibraries>false</UseDebugLibraries>
-		<PlatformToolset>v143</PlatformToolset>
-		<WholeProgramOptimization>true</WholeProgramOptimization>
-		<CharacterSet>Unicode</CharacterSet>
-	</PropertyGroup>
-	<Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
-	<ImportGroup Label="ExtensionSettings">
-	</ImportGroup>
-	<ImportGroup Label="Shared">
-	</ImportGroup>
-	<ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-		<Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-	</ImportGroup>
-	<ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
-		<Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-	</ImportGroup>
-	<ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-		<Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-	</ImportGroup>
-	<ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-		<Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-	</ImportGroup>
-	<PropertyGroup Label="UserMacros" />
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-		<LinkIncremental>true</LinkIncremental>
-		<OutDir>$(SolutionDir)bin\$(MSBuildProjectName)\$(Configuration)\$(Platform)\</OutDir>
-		<IntDir>$(SolutionDir)obj\$(MSBuildProjectName)\$(Configuration)\$(Platform)\</IntDir>
-	</PropertyGroup>
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
-		<LinkIncremental>false</LinkIncremental>
-		<OutDir>$(SolutionDir)bin\$(MSBuildProjectName)\$(Configuration)\$(Platform)\</OutDir>
-		<IntDir>$(SolutionDir)obj\$(MSBuildProjectName)\$(Configuration)\$(Platform)\</IntDir>
-	</PropertyGroup>
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-		<LinkIncremental>true</LinkIncremental>
-		<OutDir>$(SolutionDir)bin\$(MSBuildProjectName)\$(Configuration)\$(Platform)\</OutDir>
-		<IntDir>$(SolutionDir)obj\$(MSBuildProjectName)\$(Configuration)\$(Platform)\</IntDir>
-	</PropertyGroup>
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-		<LinkIncremental>false</LinkIncremental>
-		<OutDir>$(SolutionDir)bin\$(MSBuildProjectName)\$(Configuration)\$(Platform)\</OutDir>
-		<IntDir>$(SolutionDir)obj\$(MSBuildProjectName)\$(Configuration)\$(Platform)\</IntDir>
-	</PropertyGroup>
-	<PropertyGroup Label="Vcpkg" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-		<VcpkgTriplet>x86-windows-static</VcpkgTriplet>
-	</PropertyGroup>
-	<PropertyGroup Label="Vcpkg" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
-		<VcpkgTriplet>x86-windows-static</VcpkgTriplet>
-	</PropertyGroup>
-	<PropertyGroup Label="Vcpkg" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-		<VcpkgTriplet>x64-windows-static</VcpkgTriplet>
-	</PropertyGroup>
-	<PropertyGroup Label="Vcpkg" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-		<VcpkgTriplet>x64-windows-static</VcpkgTriplet>
-	</PropertyGroup>
-	<ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-		<ClCompile>
-			<WarningLevel>Level3</WarningLevel>
-			<SDLCheck>true</SDLCheck>
-			<PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-			<ConformanceMode>true</ConformanceMode>
-			<RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
-			<LanguageStandard>stdcpp17</LanguageStandard>
-		</ClCompile>
-		<Link>
-			<SubSystem>Console</SubSystem>
-			<GenerateDebugInformation>true</GenerateDebugInformation>
-		</Link>
-	</ItemDefinitionGroup>
-	<ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
-		<ClCompile>
-			<WarningLevel>Level3</WarningLevel>
-			<FunctionLevelLinking>true</FunctionLevelLinking>
-			<IntrinsicFunctions>true</IntrinsicFunctions>
-			<SDLCheck>true</SDLCheck>
-			<PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-			<ConformanceMode>true</ConformanceMode>
-			<RuntimeLibrary>MultiThreaded</RuntimeLibrary>
-			<LanguageStandard>stdcpp17</LanguageStandard>
-		</ClCompile>
-		<Link>
-			<SubSystem>Console</SubSystem>
-			<EnableCOMDATFolding>true</EnableCOMDATFolding>
-			<OptimizeReferences>true</OptimizeReferences>
-			<GenerateDebugInformation>true</GenerateDebugInformation>
-		</Link>
-	</ItemDefinitionGroup>
-	<ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-		<ClCompile>
-			<WarningLevel>Level3</WarningLevel>
-			<SDLCheck>true</SDLCheck>
-			<PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-			<ConformanceMode>true</ConformanceMode>
-		</ClCompile>
-		<Link>
-			<SubSystem>Console</SubSystem>
-			<GenerateDebugInformation>true</GenerateDebugInformation>
-		</Link>
-	</ItemDefinitionGroup>
-	<ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-		<ClCompile>
-			<WarningLevel>Level3</WarningLevel>
-			<FunctionLevelLinking>true</FunctionLevelLinking>
-			<IntrinsicFunctions>true</IntrinsicFunctions>
-			<SDLCheck>true</SDLCheck>
-			<PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-			<ConformanceMode>true</ConformanceMode>
-		</ClCompile>
-		<Link>
-			<SubSystem>Console</SubSystem>
-			<EnableCOMDATFolding>true</EnableCOMDATFolding>
-			<OptimizeReferences>true</OptimizeReferences>
-			<GenerateDebugInformation>true</GenerateDebugInformation>
-		</Link>
-	</ItemDefinitionGroup>
-	<ItemGroup>
-		<ClCompile Include="Onova.Installer.cpp" />
-	</ItemGroup>
-	<ItemGroup>
-		<ClInclude Include="Onova.Installer.h" />
-		<ClInclude Include="StringUtils.h" />
-		<ClInclude Include="WinReg.hpp" />
-		<ClInclude Include="zip_file.hpp" />
-	</ItemGroup>
-	<Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
-	<Target Name="PostBuild" AfterTargets="PostBuildEvent">
-		<Copy SourceFiles="$(SolutionDir)bin\Onova.Installer\$(ConfigurationName)\Win32\Onova.Installer.exe" 
-			  DestinationFolder="$(SolutionDir)bin\Onova.Publisher\$(ConfigurationName)\AnyCPU\net5.0\" />
-	</Target>
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <VCProjectVersion>16.0</VCProjectVersion>
+    <Keyword>Win32Proj</Keyword>
+    <ProjectGuid>{3b6ef307-2edc-44cf-9b98-7c98db4db804}</ProjectGuid>
+    <RootNamespace>OnovaInstaller</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <LinkIncremental>true</LinkIncremental>
+    <OutDir>$(SolutionDir)bin\$(MSBuildProjectName)\$(Configuration)\$(Platform)\</OutDir>
+    <IntDir>$(SolutionDir)obj\$(MSBuildProjectName)\$(Configuration)\$(Platform)\</IntDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <LinkIncremental>false</LinkIncremental>
+    <OutDir>$(SolutionDir)bin\$(MSBuildProjectName)\$(Configuration)\$(Platform)\</OutDir>
+    <IntDir>$(SolutionDir)obj\$(MSBuildProjectName)\$(Configuration)\$(Platform)\</IntDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <LinkIncremental>true</LinkIncremental>
+    <OutDir>$(SolutionDir)bin\$(MSBuildProjectName)\$(Configuration)\$(Platform)\</OutDir>
+    <IntDir>$(SolutionDir)obj\$(MSBuildProjectName)\$(Configuration)\$(Platform)\</IntDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <LinkIncremental>false</LinkIncremental>
+    <OutDir>$(SolutionDir)bin\$(MSBuildProjectName)\$(Configuration)\$(Platform)\</OutDir>
+    <IntDir>$(SolutionDir)obj\$(MSBuildProjectName)\$(Configuration)\$(Platform)\</IntDir>
+  </PropertyGroup>
+  <PropertyGroup Label="Vcpkg" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <VcpkgTriplet>x86-windows-static</VcpkgTriplet>
+  </PropertyGroup>
+  <PropertyGroup Label="Vcpkg" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <VcpkgTriplet>x86-windows-static</VcpkgTriplet>
+  </PropertyGroup>
+  <PropertyGroup Label="Vcpkg" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <VcpkgTriplet>x64-windows-static</VcpkgTriplet>
+  </PropertyGroup>
+  <PropertyGroup Label="Vcpkg" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <VcpkgTriplet>x64-windows-static</VcpkgTriplet>
+  </PropertyGroup>
+  <PropertyGroup Label="Vcpkg">
+    <VcpkgEnableManifest>true</VcpkgEnableManifest>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+      <LanguageStandard>stdcpp17</LanguageStandard>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <LanguageStandard>stdcpp17</LanguageStandard>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="Onova.Installer.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="Onova.Installer.h" />
+    <ClInclude Include="StringUtils.h" />
+    <ClInclude Include="WinReg.hpp" />
+    <ClInclude Include="zip_file.hpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="vcpkg.json" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <Target Name="PostBuild" AfterTargets="PostBuildEvent">
+    <Copy SourceFiles="$(SolutionDir)bin\Onova.Installer\$(ConfigurationName)\Win32\Onova.Installer.exe" DestinationFolder="$(SolutionDir)bin\Onova.Publisher\$(ConfigurationName)\AnyCPU\net5.0\" />
+  </Target>
 </Project>

--- a/Onova.Installer/Onova.Installer.vcxproj.filters
+++ b/Onova.Installer/Onova.Installer.vcxproj.filters
@@ -33,4 +33,7 @@
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>
+  <ItemGroup>
+    <None Include="vcpkg.json" />
+  </ItemGroup>
 </Project>

--- a/Onova.Installer/vcpkg.json
+++ b/Onova.Installer/vcpkg.json
@@ -1,0 +1,10 @@
+{
+  "name": "onova-installer",
+  "version": "1.2.4",
+  "description": "Provides publishing support for applications using Onova.",
+  "license": "MIT",
+  "supports": "!(arm | uwp)",
+  "dependencies": [
+	"cpr"
+  ]
+}

--- a/Onova.Installer/vcpkg.json
+++ b/Onova.Installer/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "onova-installer",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "description": "Provides publishing support for applications using Onova.",
   "license": "MIT",
   "supports": "!(arm | uwp)",

--- a/Onova.Publisher.nuspec
+++ b/Onova.Publisher.nuspec
@@ -14,7 +14,7 @@
     <dependencies>
       <group targetFramework="net5.0" />
       <group targetFramework="net6.0" />
-	  <group targetFramework="net7.0" />
+	    <group targetFramework="net7.0" />
     </dependencies>
     <releaseNotes>* FIX: Fixed issue with multiple nested folders not unpacking.
 	</releaseNotes>

--- a/Onova.Publisher.nuspec
+++ b/Onova.Publisher.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>Onova.Publisher</id>
     <title>Onova.Publisher</title>
-    <version>1.2.4</version>
+    <version>1.2.5</version>
     <authors>dady8889</authors>
     <owners>dady8889</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>

--- a/Onova.Publisher/Onova.Publisher.csproj
+++ b/Onova.Publisher/Onova.Publisher.csproj
@@ -5,7 +5,7 @@
         <TargetFramework>net5.0</TargetFramework>
         <Authors>dady8889</Authors>
         <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
-        <Version>1.2.4</Version>
+        <Version>1.2.5</Version>
         <RunPostBuildEvent>OnBuildSuccess</RunPostBuildEvent>
         <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
         <OutputPath>$(SolutionDir)bin\$(MSBuildProjectName)\$(Configuration)\$(Platform)\</OutputPath>

--- a/Onova.Publisher/Onova.Publisher.csproj
+++ b/Onova.Publisher/Onova.Publisher.csproj
@@ -12,6 +12,12 @@
 		<IntermediateOutputPath>$(SolutionDir)obj\$(MSBuildProjectName)\$(Configuration)\$(Platform)\</IntermediateOutputPath>
 	</PropertyGroup>
 
+	<PropertyGroup>
+    <PackAsTool>true</PackAsTool>
+    <ToolCommandName>Onova.Publisher</ToolCommandName>
+    <PackageOutputPath>./publish</PackageOutputPath>
+  </PropertyGroup>
+
 	<ItemGroup>
 		<Compile Remove="publish\**" />
 		<EmbeddedResource Remove="publish\**" />

--- a/Onova.Publisher/Onova.Publisher.csproj
+++ b/Onova.Publisher/Onova.Publisher.csproj
@@ -1,56 +1,60 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-	<PropertyGroup>
-		<OutputType>Exe</OutputType>
-		<TargetFramework>net5.0</TargetFramework>
-		<Authors>dady8889</Authors>
-		<GeneratePackageOnBuild>false</GeneratePackageOnBuild>
-		<Version>1.2.4</Version>
-		<RunPostBuildEvent>OnBuildSuccess</RunPostBuildEvent>
-		<GenerateAssemblyInfo>true</GenerateAssemblyInfo>
-		<OutputPath>$(SolutionDir)bin\$(MSBuildProjectName)\$(Configuration)\$(Platform)\</OutputPath>
-		<IntermediateOutputPath>$(SolutionDir)obj\$(MSBuildProjectName)\$(Configuration)\$(Platform)\</IntermediateOutputPath>
-	</PropertyGroup>
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <TargetFramework>net5.0</TargetFramework>
+        <Authors>dady8889</Authors>
+        <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
+        <Version>1.2.4</Version>
+        <RunPostBuildEvent>OnBuildSuccess</RunPostBuildEvent>
+        <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
+        <OutputPath>$(SolutionDir)bin\$(MSBuildProjectName)\$(Configuration)\$(Platform)\</OutputPath>
+        <IntermediateOutputPath>$(SolutionDir)obj\$(MSBuildProjectName)\$(Configuration)\$(Platform)\</IntermediateOutputPath>
+    </PropertyGroup>
 
-	<PropertyGroup>
-    <PackAsTool>true</PackAsTool>
-    <ToolCommandName>Onova.Publisher</ToolCommandName>
-    <PackageOutputPath>./publish</PackageOutputPath>
-  </PropertyGroup>
+    <PropertyGroup>
+        <PackAsTool>true</PackAsTool>
+        <ToolCommandName>Onova.Publisher</ToolCommandName>
+        <PackageOutputPath>./publish</PackageOutputPath>
+    </PropertyGroup>
+    
+    <PropertyGroup Condition="'$(SolutionDir)' == ''">
+        <SolutionDir>..\</SolutionDir>
+    </PropertyGroup>
 
-	<ItemGroup>
-		<Compile Remove="publish\**" />
-		<EmbeddedResource Remove="publish\**" />
-		<None Remove="publish\**" />
-	</ItemGroup>
+    <ItemGroup>
+        <Compile Remove="publish\**"/>
+        <EmbeddedResource Remove="publish\**"/>
+        <None Remove="publish\**"/>
+    </ItemGroup>
 
-	<ItemGroup>
-		<None Include="..\Onova.Publisher.nuspec" />
-	</ItemGroup>
+    <ItemGroup>
+        <None Include="..\Onova.Publisher.nuspec"/>
+    </ItemGroup>
 
-	<ItemGroup>
-		<PackageReference Include="NuGet.CommandLine" Version="6.3.0">
-		  <PrivateAssets>all</PrivateAssets>
-		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-		</PackageReference>
-		<PackageReference Include="signtool" Version="10.0.17763.132" />
-		<PackageReference Include="System.CommandLine" Version="2.0.0-beta1.21308.1" />
-		<PackageReference Include="System.CommandLine.Rendering" Version="0.3.0-alpha.21216.1" />
-	</ItemGroup>
+    <ItemGroup>
+        <PackageReference Include="NuGet.CommandLine" Version="6.3.0">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+        <PackageReference Include="signtool" Version="10.0.17763.132"/>
+        <PackageReference Include="System.CommandLine" Version="2.0.0-beta1.21308.1"/>
+        <PackageReference Include="System.CommandLine.Rendering" Version="0.3.0-alpha.21216.1"/>
+    </ItemGroup>
 
-	<Target Name="PostBuild" AfterTargets="PostBuildEvent">
-		<ItemGroup>
-			<SignToolFiles Include="$(NuGetPackageRoot)signtool\10.0.17763.132\tools\*.*" />
-		</ItemGroup>
-		<Copy SourceFiles="$(SolutionDir)bin\Onova.Installer\$(ConfigurationName)\Win32\Onova.Installer.exe" DestinationFolder="$(TargetDir)" />
-		<Copy SourceFiles="@(SignToolFiles)" DestinationFolder="$(TargetDir)" />
-	</Target>
+    <Target Name="PostBuild" AfterTargets="PostBuildEvent">
+        <ItemGroup>
+            <SignToolFiles Include="$(NuGetPackageRoot)signtool\10.0.17763.132\tools\*.*"/>
+        </ItemGroup>
+        <Copy SourceFiles="$(SolutionDir)bin\Onova.Installer\$(ConfigurationName)\Win32\Onova.Installer.exe" DestinationFolder="$(TargetDir)"/>
+        <Copy SourceFiles="@(SignToolFiles)" DestinationFolder="$(TargetDir)"/>
+    </Target>
 
-	<Target Name="PostPublish" AfterTargets="Publish">
-		<ItemGroup>
-			<SignToolFiles Include="$(NuGetPackageRoot)signtool\10.0.17763.132\tools\*.*" />
-		</ItemGroup>
-		<Copy SourceFiles="$(SolutionDir)bin\Onova.Installer\$(ConfigurationName)\Win32\Onova.Installer.exe" DestinationFolder="$(PublishDir)" />
-		<Copy SourceFiles="@(SignToolFiles)" DestinationFolder="$(PublishDir)" />
-	</Target>
+    <Target Name="PostPublish" AfterTargets="Publish">
+        <ItemGroup>
+            <SignToolFiles Include="$(NuGetPackageRoot)signtool\10.0.17763.132\tools\*.*"/>
+        </ItemGroup>
+        <Copy SourceFiles="$(SolutionDir)bin\Onova.Installer\$(ConfigurationName)\Win32\Onova.Installer.exe" DestinationFolder="$(PublishDir)"/>
+        <Copy SourceFiles="@(SignToolFiles)" DestinationFolder="$(PublishDir)"/>
+    </Target>
 </Project>

--- a/README.md
+++ b/README.md
@@ -136,19 +136,6 @@ PM> Onova.Publisher --name DummyApp --version 1.3.0 --url https://dummy.com/file
 - [x] App name allows only ANSI encoding
 - [x] MANIFEST rebuilding sorts alphabetically, not semantically
 
-## Building
-
-First, you need to setup the `vcpkg` Package Manager, more info [here](https://vcpkg.io/en/getting-started.html).
-
-```sh
-cd vcpkg
-./vcpkg install cpr:x86-windows-static
-
-git clone https://github.com/dady8889/Onova.Publisher.git
-
-# Build Solution in VS2022
-```
-
 ## Contributions
 I am open to suggestions, PRs, bug reports.
 Any contribution is welcome.


### PR DESCRIPTION
Fixes #1 

## Changes

- Added `vcpkg.json` manifest so the user has one less step required on building the solution
  - Removed that now obsolete step from the README
- Modified the `.csproj` as recommended [in the MS docs](https://learn.microsoft.com/en-us/dotnet/core/tools/global-tools-how-to-create)